### PR TITLE
Shift certificate expiration date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.github.ganskef</groupId>
     <artifactId>littleproxy-mitm</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-VGS</version>
+    <version>1.0.1-VGS</version>
     <name>LittleProxy - Man-In-The-Middle</name>
     <description>LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.
 

--- a/src/main/java/org/littleshoot/proxy/mitm/CertificateHelper.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/CertificateHelper.java
@@ -226,8 +226,13 @@ public final class CertificateHelper {
         name.addRDN(BCStyle.OU, authority.certOrganizationalUnitName());
         X500Name subject = name.build();
 
+        // originally the date was plus one day but in some cases (to be investigated)
+        // it caused expired certificate errors (probably a connection was held for more than 1 day)
+        // so the quick fix was to shift the date to plus one month
+        final Date certExpirationDate = new Date(System.currentTimeMillis() + ONE_DAY * 30);
+
         X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(issuer, serial, NOT_BEFORE,
-                new Date(System.currentTimeMillis() + ONE_DAY), subject, keyPair.getPublic());
+            certExpirationDate, subject, keyPair.getPublic());
 
         builder.addExtension(Extension.subjectKeyIdentifier, false,
                 createSubjectKeyIdentifier(keyPair.getPublic()));


### PR DESCRIPTION
This is a quick fix to resolve an error that occurs for i2c proxy when the certificate is not regenerated and gets expired. The root cause is not found yet. 

Let me check if I can write a test for that