### PR TITLE
Certificate cache expiration fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.github.ganskef</groupId>
     <artifactId>littleproxy-mitm</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-VGS</version>
+    <version>1.0.1-VGS</version>
     <name>LittleProxy - Man-In-The-Middle</name>
     <description>LittleProxy is a high performance HTTP proxy written in Java and using the Netty networking framework.
 

--- a/src/main/java/org/littleshoot/proxy/mitm/BouncyCastleSslEngineSource.java
+++ b/src/main/java/org/littleshoot/proxy/mitm/BouncyCastleSslEngineSource.java
@@ -147,6 +147,7 @@ public class BouncyCastleSslEngineSource implements SslEngineSource {
     private static Cache<String, SSLContext> initDefaultCertificateCache() {
         return CacheBuilder.newBuilder() //
                 .expireAfterAccess(5, TimeUnit.MINUTES) //
+                .expireAfterWrite(12, TimeUnit.HOURS)
                 .concurrencyLevel(16) //
                 .build();
     }


### PR DESCRIPTION
# # Fixes: https://app.clubhouse.io/vgs/story/4210/fix-certificate-cache-in-mitm

Expires certificate cache in 12 hours after write access